### PR TITLE
Debug boutique deployment on vercel

### DIFF
--- a/cbd-boutique/src/types/index.ts
+++ b/cbd-boutique/src/types/index.ts
@@ -67,7 +67,7 @@ export interface CloudinaryUploadResult {
   placeholder: boolean;
   url: string;
   secure_url: string;
-  folder: string;
+  folder?: string;
   original_filename: string;
-  api_key: string;
+  api_key?: string;
 }


### PR DESCRIPTION
Make `folder` and `api_key` optional in `CloudinaryUploadResult` to resolve a TypeScript type error preventing Vercel deployment.