### PR TITLE
Debug boutique deployment on vercel

### DIFF
--- a/cbd-boutique/src/types/index.ts
+++ b/cbd-boutique/src/types/index.ts
@@ -67,7 +67,5 @@ export interface CloudinaryUploadResult {
   placeholder: boolean;
   url: string;
   secure_url: string;
-  folder: string;
   original_filename: string;
-  api_key: string;
 }


### PR DESCRIPTION
Remove `folder` and `api_key` from `CloudinaryUploadResult` type to resolve a TypeScript error preventing Vercel deployment.

The `CloudinaryUploadResult` type was incorrectly defined, including properties (`folder`, `api_key`) that are not present in Cloudinary's `UploadApiResponse` type, leading to a TypeScript build error. This fix aligns the local type definition with the actual Cloudinary API response.